### PR TITLE
Fix: fix gettext matching error for show.html.eex

### DIFF
--- a/apps/explorer/lib/explorer/counters/average_block_time_duration_format.ex
+++ b/apps/explorer/lib/explorer/counters/average_block_time_duration_format.ex
@@ -36,7 +36,7 @@ defmodule Explorer.Counters.AverageBlockTimeDurationFormat do
       "1.1 minutes"
   """
   @spec format(Duration.t()) :: String.t() | {:error, term}
-  def format(%Duration{} = duration), do: lformat(duration, Translator.default_locale())
+  def format(%Duration{} = duration), do: lformat(duration, Translator.current_locale())
   def format(_), do: {:error, :invalid_duration}
 
   @doc """
@@ -88,13 +88,17 @@ defmodule Explorer.Counters.AverageBlockTimeDurationFormat do
     truncated = trunc(decimal_value)
 
     # remove any trailing `.0`
-    formatted_value =
-      if decimal_value == truncated do
-        truncated
-      else
-        Float.round(decimal_value, 1)
-      end
+    if decimal_value == truncated do
+      Translator.translate_plural(locale, "units", "%{count} #{singular}", "%{count} #{singular}s", truncated)
+    else
+      value =
+        decimal_value
+        |> Float.round(1)
+        |> :erlang.float_to_binary(decimals: 1)
 
-    Translator.translate_plural(locale, "units", "%{count} #{singular}", "%{count} #{singular}s", formatted_value)
+      locale
+      |> Translator.translate_plural("units", "%{count} #{singular}", "%{count} #{singular}s", 5)
+      |> String.replace("5", value)
+    end
   end
 end

--- a/apps/indexer/config/dev.exs
+++ b/apps/indexer/config/dev.exs
@@ -33,7 +33,7 @@ config :logger, :empty_blocks_to_refetch,
 
 variant =
   if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do
-    "ganache"
+    "geth"
   else
     System.get_env("ETHEREUM_JSONRPC_VARIANT")
     |> String.split(".")

--- a/apps/indexer/config/prod.exs
+++ b/apps/indexer/config/prod.exs
@@ -39,7 +39,7 @@ config :logger, :empty_blocks_to_refetch,
 
 variant =
   if is_nil(System.get_env("ETHEREUM_JSONRPC_VARIANT")) do
-    "parity"
+    "geth"
   else
     System.get_env("ETHEREUM_JSONRPC_VARIANT")
     |> String.split(".")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
     #   -  ./docker-compose/envs/common-blockscout.env
 
     environment:
+      - MIX_ENV=prod
       - DOCKER_TAG
       - ETHEREUM_JSONRPC_VARIANT
       - ETHEREUM_JSONRPC_HTTP_URL


### PR DESCRIPTION
## Summary
issue link #27 
Fix: fix gettext matching error for show.html.eex of `AverageBlockTimeDurationFormat` when display float value